### PR TITLE
[SYCL] Add POC of virtual functions support in SYCL RT

### DIFF
--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -501,7 +501,7 @@ std::string saveModuleProperties(module_split::ModuleDesc &MD,
     // Virtual functions
     if (NamedMDNode *IC = M.getNamedMetadata("indirectly-callable")) {
       PropSet[PropSetRegTy::SYCL_VIRTUAL_FUNCTIONS].insert(
-          {"exports-virtual-functions-set",
+          {"virtual-functions-set",
            cast<MDString>(IC->getOperand(0)->getOperand(0))->getString()});
 
     } else if (NamedMDNode *CI = M.getNamedMetadata("calls-indirectly")) {
@@ -511,7 +511,7 @@ std::string saveModuleProperties(module_split::ModuleDesc &MD,
         V += Set;
       }
       PropSet[PropSetRegTy::SYCL_VIRTUAL_FUNCTIONS].insert(
-          {"uses-virtual-functions-sets", V});
+          {"calls-virtual-functions-set", V});
     }
   }
 

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -310,7 +310,8 @@ private:
                    const std::string &CompileOptions,
                    const std::string &LinkOptions,
                    const sycl::detail::pi::PiDevice &Device,
-                   uint32_t DeviceLibReqMask);
+                   uint32_t DeviceLibReqMask,
+                   std::vector<sycl::detail::pi::PiProgram> ProgramsToLink);
   /// Dumps image to current directory
   void dumpImage(const RTDeviceBinaryImage &Img, uint32_t SequenceID = 0) const;
 
@@ -335,7 +336,10 @@ private:
   std::unordered_multimap<kernel_id, RTDeviceBinaryImage *>
       m_KernelIDs2BinImage;
 
-  std::unordered_map<std::string, RTDeviceBinaryImage *> m_VFSet2BinImage;
+  std::unordered_map<std::string, std::set<RTDeviceBinaryImage *>>
+      m_VFSet2BinImage;
+
+  std::set<RTDeviceBinaryImage *> m_DummyBinImages;
 
   // Maps device binary image to a vector of kernel ids in this image.
   // Using shared_ptr to avoid expensive copy of the vector.


### PR DESCRIPTION
The patch was made in accordance with new virtual functions spec changes and new design introduced in
https://github.com/intel/llvm/pull/10540/files

The SYCL compiler is buildable without errors and new warnings with this patch.